### PR TITLE
Only show pixel messages when in debug mode

### DIFF
--- a/Sources/discovery-ios-sdk/pixel/network/RestClient.swift
+++ b/Sources/discovery-ios-sdk/pixel/network/RestClient.swift
@@ -67,7 +67,9 @@ class RestClient {
         guard let urlRequest = components.url else { return }
         
         var request = URLRequest(url: urlRequest)
-        print("url: \(String(describing: request.url))")
+        if (PixelTracker.shared.brPixel!.debugMode) {
+            print("url: \(String(describing: request.url))")
+        }
         request.httpMethod = "GET"
         request.setValue(FormatterUtils.shared.getUserAgent(), forHTTPHeaderField:  "User-Agent")
 
@@ -78,9 +80,13 @@ class RestClient {
             if let httpResponse = response as? HTTPURLResponse {
                 switch httpResponse.statusCode {
                 case 200..<300:
-                    print("submitPixel success \(httpResponse.statusCode)")
+                    if (PixelTracker.shared.brPixel!.debugMode) {
+                        print("submitPixel success \(httpResponse.statusCode)")
+                    }
                 default:
-                    print("submitPixel failure \(httpResponse.statusCode)")
+                    if (PixelTracker.shared.brPixel!.debugMode) {
+                        print("submitPixel failure \(httpResponse.statusCode)")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adding this debug check allows the console to remain clear when building other parts of the app. 

Should the developer need to confirm that pixels are being submitted successfully they are still able to set debugMode to true and these messages will be shown in the console again.